### PR TITLE
feat: update photo list handling in EditorChoiceComponent and add lin…

### DIFF
--- a/src/component/homepage/EditorChoiceComponent.vue
+++ b/src/component/homepage/EditorChoiceComponent.vue
@@ -15,7 +15,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="global-container" v-if="photoList.length > 0">
+  <div class="global-container" v-if="photoList.length > 4">
     <div class="flex flex-col gap-8">
       <h2>编辑精选</h2>
       <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">

--- a/src/component/homepage/EditorChoiceComponent.vue
+++ b/src/component/homepage/EditorChoiceComponent.vue
@@ -8,11 +8,7 @@ onMounted(async () => {
   const photoListReq = new ServerRequest("GET", "/photos?type=ScreenerChoice");
   photoListReq.success = () => {
     const d = photoListReq.getData() as AcceptPhoto[];
-    if (d.length > 8) {
-      photoList.value = d.slice(0, 8);
-    } else {
-      photoList.value = d;
-    }
+    photoList.value = d.slice(0, Math.min(d.length - (d.length % 4), 8));
   };
   await photoListReq.send();
 });
@@ -25,6 +21,11 @@ onMounted(async () => {
       <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         <PhotoCard v-for="photo in photoList" v-bind="photo" :key="photo.id" />
       </div>
+    </div>
+    <div class="pt-4">
+      <ElButton type="text">
+        <router-link to="/editorChoice">查看全部编辑精选 &gt;</router-link>
+      </ElButton>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This pull request updates the logic for displaying the editor's choice photos on the homepage, ensuring a more consistent layout and improving user navigation. The main changes are related to how the photo list is sliced and displayed, and an additional button has been added for easier access to the full selection.

Photo list display logic:

* The slicing logic for `photoList` now ensures the number of displayed photos is both a multiple of four and no more than eight, which helps maintain a consistent grid layout.
* The container now only renders if there are more than four photos, instead of any nonzero amount, ensuring the grid looks balanced.

User interface improvements:

* A new button has been added below the photo grid, allowing users to navigate to the full editor's choice page for more selections.