### PR TITLE
fix: EditorChoiceComponent

### DIFF
--- a/src/component/homepage/EditorChoiceComponent.vue
+++ b/src/component/homepage/EditorChoiceComponent.vue
@@ -15,7 +15,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="global-container" v-if="photoList.length > 4">
+  <div class="global-container" v-if="photoList.length >= 4">
     <div class="flex flex-col gap-8">
       <h2>编辑精选</h2>
       <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">


### PR DESCRIPTION
This pull request makes a minor update to the conditional rendering logic in the `EditorChoiceComponent.vue` file. The change ensures that the component displays when there are at least four photos, rather than only when there are more than four.

* Updated the conditional in the template to render the `.global-container` when `photoList.length` is greater than or equal to 4, instead of strictly greater than 4. (`src/component/homepage/EditorChoiceComponent.vue`)