### PR TITLE
fix: update header key for local ID in request configuration

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -38,7 +38,7 @@ export default class ServerRequest {
     }
     return {
       "Content-Type": contentType,
-      t_id: this.localId.id,
+      "X-tId": this.localId.id,
       Authorization: this.user.isLoggedIn ? "Bearer " + this.user.token : "",
     };
   }


### PR DESCRIPTION
This pull request updates the request header naming convention in the `ServerRequest` class to improve clarity and standardization.

Header naming update:

* Changed the custom header from `t_id` to `X-tId` in the `ServerRequest` class within `src/utils/request.ts`.