### PR TITLE
feat/4k upload

### DIFF
--- a/src/utils/check-image.ts
+++ b/src/utils/check-image.ts
@@ -34,7 +34,7 @@ export async function checkImage(rawFile: UploadRawFile) {
   if (longSide > 2160) {
     ElNotification.error({
       title: "图片分辨率过高",
-      message: "长边需小于2160像素",
+      message: "长边需小于等于2160像素",
     });
     return false;
   }

--- a/src/utils/check-image.ts
+++ b/src/utils/check-image.ts
@@ -1,12 +1,18 @@
 import type { UploadRawFile } from "element-plus";
-import { ElMessage } from "element-plus";
+import { ElNotification } from "element-plus";
 export async function checkImage(rawFile: UploadRawFile) {
   if (rawFile.type !== "image/jpeg") {
-    ElMessage.error("格式错误");
+    ElNotification.error({
+      title: "文件错误",
+      message: "我们只支持 JPEG 格式的图片",
+    });
     return false;
   }
-  if (rawFile.size / 1024 / 1024 > 4) {
-    ElMessage.error("图片大于4MB");
+  if (rawFile.size / 1024 / 1024 > 8) {
+    ElNotification.error({
+      title: "文件错误",
+      message: "图片大小不能超过8MB",
+    });
     return false;
   }
 
@@ -18,10 +24,19 @@ export async function checkImage(rawFile: UploadRawFile) {
   img.src = fileReader.result as string;
   await new Promise<void>((resolve) => (img.onload = () => resolve()));
   const longSide = Math.max(img.width, img.height);
-  if (longSide < 1279 || longSide > 1920) {
-    ElMessage.warning("尺寸超限");
+  if (longSide < 1279) {
+    ElNotification.error({
+      title: "图片分辨率过低",
+      message: "长边需大于1280像素",
+    });
     return false;
   }
-
+  if (longSide > 2160) {
+    ElNotification.error({
+      title: "图片分辨率过高",
+      message: "长边需小于2160像素",
+    });
+    return false;
+  }
   return true;
 }

--- a/src/views/photo/UploadView.vue
+++ b/src/views/photo/UploadView.vue
@@ -389,7 +389,7 @@ const readExifDate = async (file: UploadFile) => {
               将文件拖拽到此处或<em>点此上传</em>
             </div>
             <template #tip>
-              <div class="el-upload__tip">只接受JPEG文件，文件不大于4MB。</div>
+              <div class="el-upload__tip">只接受JPEG文件，文件不大于8MB。</div>
             </template>
           </el-upload>
         </el-form-item>

--- a/src/views/photo/UploadView.vue
+++ b/src/views/photo/UploadView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { onMounted, reactive, ref, watch } from "vue";
-import { useRoute } from "vue-router";
 
 import { UploadFilled } from "@element-plus/icons-vue";
 import type {
@@ -64,7 +63,6 @@ const elemStatus = reactive({
   watermark: false,
 });
 const localUserInfo = useUserInfoStore();
-const route = useRoute();
 
 const init = async () => {
   const userInfoReq = new ServerRequest("GET", `/user/${localUserInfo.id}`);
@@ -198,12 +196,8 @@ async function preCheck() {
 
   if (!(await checkImage(FILE))) return;
 
-  return showWatermarkDialog();
-}
-
-const showWatermarkDialog = () => {
   elemStatus.watermark = true;
-};
+}
 
 async function upload() {
   let uploading = ElLoading.service({


### PR DESCRIPTION
This pull request updates the image upload validation and user feedback mechanisms to improve the user experience and align with new requirements. The main changes include increasing the allowed image size, refining image resolution checks, and switching from message popups to notifications for error reporting.

**Image validation and user feedback improvements:**

* Increased the maximum allowed image size from 4MB to 8MB, and updated the UI tip to reflect this new limit. [[1]](diffhunk://#diff-92f21512f05046ace2cd30662e728cc6ba3513de5aec1f7835c4be3e7d6b43ceL2-R15) [[2]](diffhunk://#diff-9b028ba6217d8cb38a22752e2375aa82ba3f47e8abae13f83dd00719cbd8faa8L398-R392)
* Changed error reporting from `ElMessage` popups to more informative `ElNotification` notifications, providing clearer error titles and messages for file type, size, and resolution issues. [[1]](diffhunk://#diff-92f21512f05046ace2cd30662e728cc6ba3513de5aec1f7835c4be3e7d6b43ceL2-R15) [[2]](diffhunk://#diff-92f21512f05046ace2cd30662e728cc6ba3513de5aec1f7835c4be3e7d6b43ceL21-L25)
* Refined image resolution validation: now explicitly checks for a minimum long side of 1280 pixels and a maximum of 2160 pixels, providing specific notifications for each case.

**Code cleanup and simplification:**

* Removed unused import of `useRoute` and related code from `UploadView.vue` to streamline the component. [[1]](diffhunk://#diff-9b028ba6217d8cb38a22752e2375aa82ba3f47e8abae13f83dd00719cbd8faa8L3) [[2]](diffhunk://#diff-9b028ba6217d8cb38a22752e2375aa82ba3f47e8abae13f83dd00719cbd8faa8L67)
* Inlined the watermark dialog logic into the `preCheck` function, simplifying the flow and removing an unnecessary function.